### PR TITLE
Using absolute import if possible

### DIFF
--- a/zdict/__init__.py
+++ b/zdict/__init__.py
@@ -1,3 +1,3 @@
-from . import utils
-from .constants import VERSION as __version__
-from .api import dump
+from zdict import utils
+from zdict.api import dump
+from zdict.constants import VERSION as __version__

--- a/zdict/__main__.py
+++ b/zdict/__main__.py
@@ -1,4 +1,4 @@
-from .zdict import main
+from zdict.zdict import main
 
 
 if __name__ == '__main__':

--- a/zdict/api.py
+++ b/zdict/api.py
@@ -1,6 +1,6 @@
 import re
 
-from .models import Record, db
+from zdict.models import Record, db
 
 
 def dump(pattern=r'^.*$'):

--- a/zdict/completer.py
+++ b/zdict/completer.py
@@ -1,4 +1,4 @@
-from .models import Record, db
+from zdict.models import Record, db
 
 
 class DictCompleter:

--- a/zdict/dictionaries/jisho.py
+++ b/zdict/dictionaries/jisho.py
@@ -1,8 +1,8 @@
 import json
 
-from ..dictionary import DictBase
-from ..exceptions import NotFoundError
-from ..models import Record
+from zdict.dictionary import DictBase
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
 
 
 class JishoDict(DictBase):

--- a/zdict/dictionaries/moe.py
+++ b/zdict/dictionaries/moe.py
@@ -1,8 +1,8 @@
 import json
 
-from ..dictionary import DictBase
-from ..exceptions import QueryError, NotFoundError
-from ..models import Record
+from zdict.dictionary import DictBase
+from zdict.exceptions import QueryError, NotFoundError
+from zdict.models import Record
 
 
 class MoeDict(DictBase):

--- a/zdict/dictionaries/spanish.py
+++ b/zdict/dictionaries/spanish.py
@@ -2,9 +2,9 @@ import json
 
 from bs4 import BeautifulSoup
 
-from ..dictionary import DictBase
-from ..exceptions import NotFoundError
-from ..models import Record
+from zdict.dictionary import DictBase
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
 
 
 # [TODO]

--- a/zdict/dictionaries/template.py
+++ b/zdict/dictionaries/template.py
@@ -2,9 +2,9 @@ import json
 
 from bs4 import BeautifulSoup
 
-from ..dictionary import DictBase
-from ..exceptions import NotFoundError
-from ..models import Record
+from zdict.dictionary import DictBase
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
 
 
 # Change `Template` to the name of new dictionary. like xxxDict.

--- a/zdict/dictionaries/urban.py
+++ b/zdict/dictionaries/urban.py
@@ -1,8 +1,8 @@
 import json
 
-from ..dictionary import DictBase
-from ..exceptions import NotFoundError
-from ..models import Record
+from zdict.dictionary import DictBase
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
 
 class UrbanDict(DictBase):
 

--- a/zdict/dictionaries/yahoo.py
+++ b/zdict/dictionaries/yahoo.py
@@ -4,9 +4,9 @@ import re
 
 from bs4 import BeautifulSoup
 
-from ..dictionary import DictBase
-from ..exceptions import NotFoundError
-from ..models import Record
+from zdict.dictionary import DictBase
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
 
 
 class YahooDict(DictBase):

--- a/zdict/dictionary.py
+++ b/zdict/dictionary.py
@@ -3,9 +3,9 @@ import json
 
 import requests
 
-from . import exceptions
-from .models import Record, db
-from .utils import Color
+from zdict import exceptions
+from zdict.models import Record, db
+from zdict.utils import Color
 
 
 class DictBase(metaclass=abc.ABCMeta):

--- a/zdict/easter_eggs.py
+++ b/zdict/easter_eggs.py
@@ -5,8 +5,8 @@ import random
 import importlib
 import importlib.util
 
-from .models import Record
-from .utils import Color
+from zdict.models import Record
+from zdict.utils import Color
 
 
 def import_pyjokes_module():

--- a/zdict/loader.py
+++ b/zdict/loader.py
@@ -5,8 +5,8 @@ from inspect import getmembers
 from importlib import find_loader, import_module
 from itertools import chain
 
-from . import dictionaries
-from .dictionary import DictBase
+from zdict import dictionaries
+from zdict.dictionary import DictBase
 
 
 def get_dictionary_map():

--- a/zdict/models.py
+++ b/zdict/models.py
@@ -1,6 +1,6 @@
 import peewee
 
-from .constants import DB_FILE
+from zdict.constants import DB_FILE
 
 
 db = peewee.SqliteDatabase(DB_FILE)

--- a/zdict/tests/dictionaries/spanish/test_spanish.py
+++ b/zdict/tests/dictionaries/spanish/test_spanish.py
@@ -4,9 +4,9 @@ import os
 from pytest import raises
 from unittest.mock import Mock, patch
 
-from ....dictionaries.spanish import SpanishDict
-from ....exceptions import NotFoundError
-from ....models import Record
+from zdict.dictionaries.spanish import SpanishDict
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
 
 
 RAW_HTML_TEST_DATA = os.path.join(os.path.dirname(__file__), 'testdata.html')

--- a/zdict/tests/dictionaries/test_jisho.py
+++ b/zdict/tests/dictionaries/test_jisho.py
@@ -3,9 +3,9 @@ import json
 from pytest import raises
 from unittest.mock import Mock, patch
 
-from ...dictionaries.jisho import JishoDict
-from ...exceptions import NotFoundError
-from ...models import Record
+from zdict.dictionaries.jisho import JishoDict
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
 
 
 class TestJishoDict:

--- a/zdict/tests/dictionaries/test_moe.py
+++ b/zdict/tests/dictionaries/test_moe.py
@@ -1,6 +1,6 @@
-from ...dictionaries.moe import MoeDict
-from ...exceptions import NotFoundError, QueryError
-from ...models import Record
+from zdict.dictionaries.moe import MoeDict
+from zdict.exceptions import NotFoundError, QueryError
+from zdict.models import Record
 
 from pytest import raises
 from unittest.mock import Mock, patch

--- a/zdict/tests/dictionaries/test_urban.py
+++ b/zdict/tests/dictionaries/test_urban.py
@@ -1,6 +1,6 @@
-from ...dictionaries.urban import UrbanDict
-from ...exceptions import NotFoundError
-from ...models import Record
+from zdict.dictionaries.urban import UrbanDict
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
 
 from pytest import raises
 from unittest.mock import Mock, patch

--- a/zdict/tests/dictionaries/test_yahoo.py
+++ b/zdict/tests/dictionaries/test_yahoo.py
@@ -1,4 +1,4 @@
-from ...dictionaries.yahoo import YahooDict
+from zdict.dictionaries.yahoo import YahooDict
 
 
 class TestyDict:

--- a/zdict/tests/test_api.py
+++ b/zdict/tests/test_api.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, Mock
+
 from zdict.api import dump
 
 

--- a/zdict/tests/test_completer.py
+++ b/zdict/tests/test_completer.py
@@ -1,5 +1,6 @@
 from pytest import raises
 from unittest.mock import patch, Mock
+
 from zdict.completer import DictCompleter
 
 

--- a/zdict/tests/test_easter_eggs.py
+++ b/zdict/tests/test_easter_eggs.py
@@ -1,4 +1,4 @@
-from ..easter_eggs import (import_pyjokes_module, get_pyjoke)
+from zdict.easter_eggs import (import_pyjokes_module, get_pyjoke)
 
 from unittest.mock import patch
 

--- a/zdict/tests/test_loader.py
+++ b/zdict/tests/test_loader.py
@@ -1,5 +1,5 @@
-from ..loader import _is_dict, get_dictionary_map
-from ..dictionary import DictBase
+from zdict.loader import _is_dict, get_dictionary_map
+from zdict.dictionary import DictBase
 
 from unittest.mock import MagicMock, Mock, patch
 
@@ -39,7 +39,7 @@ def test_get_dictionary_map(listdir, import_module, getmembers):
         'not_a_py.rst',
     ]
     getmembers.return_value = [('mock', MockDict)]
-    
+
     dict_map = get_dictionary_map()
 
     assert dict_map == {'mock': MockDict}

--- a/zdict/utils.py
+++ b/zdict/utils.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from . import constants
+from zdict import constants
 
 
 def create_zdict_dir_if_not_exists():

--- a/zdict/zdict.py
+++ b/zdict/zdict.py
@@ -2,11 +2,11 @@ import locale
 
 from argparse import ArgumentParser
 
-from . import constants, utils, easter_eggs
-from .completer import DictCompleter
-from .loader import get_dictionary_map
-from .utils import readline, check_zdict_dir_and_db
-from .api import dump
+from zdict import constants, utils, easter_eggs
+from zdict.api import dump
+from zdict.completer import DictCompleter
+from zdict.loader import get_dictionary_map
+from zdict.utils import readline, check_zdict_dir_and_db
 
 
 def user_set_encoding_and_is_utf8():


### PR DESCRIPTION
http://pep8.org/#imports
> Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages) if the import system is incorrectly configured (such as when a directory inside a package ends up on sys.path):