### PR TITLE
Can not initiate interactive mode

### DIFF
--- a/zdict/tests/dictionaries/test_spanish.py
+++ b/zdict/tests/dictionaries/test_spanish.py
@@ -6,7 +6,7 @@ from zdict.exceptions import NotFoundError
 from zdict.zdict import get_args
 
 
-class TestSpansishDict:
+class TestSpanishDict:
     @classmethod
     def setup_class(cls):
         cls.dict = SpanishDict(get_args())

--- a/zdict/zdict.py
+++ b/zdict/zdict.py
@@ -232,7 +232,9 @@ def normal_mode(args):
 class MetaInteractivePrompt():
     def __init__(self, args):
         self.args = args
-        self.dicts = tuple(dictionary_map[d]() for d in self.args.dict)
+        self.dicts = tuple(
+            dictionary_map[d](self.args) for d in self.args.dict
+        )
         self.dict_classes = tuple(dictionary_map[d] for d in self.args.dict)
 
         if self.args.jobs == 0:
@@ -260,7 +262,7 @@ class MetaInteractivePrompt():
                 print(''.join(results))
             else:
                 for dictionary_instance in self.dicts:
-                    dictionary_instance.lookup(user_input, self.args)
+                    dictionary_instance.lookup(user_input)
         else:
             return
 


### PR DESCRIPTION
```
Exception ignored in: <bound method DictBase.__del__ of <zdict.dictionaries.yahoo.YahooDict object at 0x7ff95fbf0d68>>
Traceback (most recent call last):
  File "/home/m157q/github/zdict/zdict/dictionary.py", line 29, in __del__
    del self.args
AttributeError: args
Traceback (most recent call last):
  File "/home/m157q/.virtualenvs/py3/bin/zdict", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/m157q/github/zdict/scripts/zdict", line 4, in <module>
    zdict.main()
  File "/home/m157q/github/zdict/zdict/zdict.py", line 302, in main
    execute_zdict(args)
  File "/home/m157q/github/zdict/zdict/zdict.py", line 286, in execute_zdict
    interactive_mode(args)
  File "/home/m157q/github/zdict/zdict/zdict.py", line 277, in interactive_mode
    zdict = MetaInteractivePrompt(args)
  File "/home/m157q/github/zdict/zdict/zdict.py", line 235, in __init__
    self.dicts = tuple(dictionary_map[d]() for d in self.args.dict)
  File "/home/m157q/github/zdict/zdict/zdict.py", line 235, in <genexpr>
    self.dicts = tuple(dictionary_map[d]() for d in self.args.dict)
TypeError: __init__() missing 1 required positional argument: 'args'
Exception ignored in: <bound method MetaInteractivePrompt.__del__ of <zdict.zdict.MetaInteractivePrompt object at 0x7ff960cb27f0>>
Traceback (most recent call last):
  File "/home/m157q/github/zdict/zdict/zdict.py", line 247, in __del__
    del self.dicts
AttributeError: dicts
```