### PR TITLE
Installed and get an exception

### DIFF
--- a/zdict/dictionary.py
+++ b/zdict/dictionary.py
@@ -16,18 +16,28 @@ class DictBase(metaclass=abc.ABCMeta):
 
     def __init__(self, args):
         self.args = args
-        self.db = db
-        self.db.connect()
-
-        for req in self.REQUIRED_TABLE:
-            if not req.table_exists():
-                req.create_table()
-
         self.color = Color()
+        self.db = db
+
+        try:
+            self.db.connect()
+        except:
+            self.db = None
+            raise
+        else:
+            for req in self.REQUIRED_TABLE:
+                if not req.table_exists():
+                    req.create_table()
 
     def __del__(self):
         del self.args
-        self.db.close()
+        del self.color
+
+        if self.db:
+            try:
+                self.db.close()
+            except AttributeError:
+                raise RuntimeError('db cannot be closed properly.')
         del self.db
 
     @property


### PR DESCRIPTION
```python
$ zdict hello
Traceback (most recent call last):
  File "/usr/local/bin/zdict", line 4, in <module>
    zdict.main()
  File "/usr/local/lib/python3.4/site-packages/zdict/zdict.py", line 211, in main
    dictionary_map = get_dictionary_map()
  File "/usr/local/lib/python3.4/site-packages/zdict/loader.py", line 30, in get_dictionary_map
    for f in os.listdir(dictionaries.__path__[0])
  File "/usr/local/lib/python3.4/site-packages/zdict/loader.py", line 25, in <dictcomp>
    for _, cls in (chain.from_iterable(
  File "/usr/local/lib/python3.4/site-packages/zdict/dictionary.py", line 19, in __init__
    self.db.connect()
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3371, in connect
    **self.connect_kwargs)
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3609, in _connect
    conn = sqlite3.connect(database, **kwargs)
AttributeError: 'NoneType' object has no attribute 'connect'
Exception ignored in: <bound method JishoDict.__del__ of <zdict.dictionaries.jisho.JishoDict object at 0x1030b1a20>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/zdict/dictionary.py", line 28, in __del__
    self.db.close()
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3384, in close
    self._close(self.__local.conn)
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3403, in _close
    conn.close()
AttributeError: 'NoneType' object has no attribute 'close'
```
Even just `--help` fails.
```python
$ zdict --help
Traceback (most recent call last):
  File "/usr/local/bin/zdict", line 4, in <module>
    zdict.main()
  File "/usr/local/lib/python3.4/site-packages/zdict/zdict.py", line 211, in main
    dictionary_map = get_dictionary_map()
  File "/usr/local/lib/python3.4/site-packages/zdict/loader.py", line 30, in get_dictionary_map
    for f in os.listdir(dictionaries.__path__[0])
  File "/usr/local/lib/python3.4/site-packages/zdict/loader.py", line 25, in <dictcomp>
    for _, cls in (chain.from_iterable(
  File "/usr/local/lib/python3.4/site-packages/zdict/dictionary.py", line 19, in __init__
    self.db.connect()
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3371, in connect
    **self.connect_kwargs)
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3609, in _connect
    conn = sqlite3.connect(database, **kwargs)
AttributeError: 'NoneType' object has no attribute 'connect'
Exception ignored in: <bound method JishoDict.__del__ of <zdict.dictionaries.jisho.JishoDict object at 0x10cff8a20>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/zdict/dictionary.py", line 28, in __del__
    self.db.close()
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3384, in close
    self._close(self.__local.conn)
  File "/usr/local/lib/python3.4/site-packages/peewee.py", line 3403, in _close
    conn.close()
AttributeError: 'NoneType' object has no attribute 'close'
```