### PR TITLE
zdict-0.9.2 ``-ld`` option is broken

### DIFF
--- a/zdict/zdict.py
+++ b/zdict/zdict.py
@@ -157,9 +157,15 @@ def get_args():
 def set_args(args):
     if args.list_dicts:
         for provider in sorted(
-                dictionary_map,
-                key=lambda x: {'yahoo': 0, 'pyjokes': 2}.get(x, 1)):
-            print('{}: {}'.format(provider, dictionary_map[provider]().title))
+            dictionary_map,
+            key=lambda x: {'yahoo': 0, 'pyjokes': 2}.get(x, 1)
+        ):
+            print(
+                '{}: {}'.format(
+                    provider,
+                    dictionary_map[provider](args).title
+                )
+            )
         exit()
 
     if args.pattern:


### PR DESCRIPTION
```
$ zdict --list-dict
Exception ignored in: <bound method DictBase.__del__ of <zdict.dictionaries.yahoo.YahooDict object at 0x10f1e73c8>>
Traceback (most recent call last):
  File "/Users/cychih/bin/.repos/zdict/zdict/dictionary.py", line 29, in __del__
    del self.args
AttributeError: args
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.5/bin/zdict", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/cychih/bin/.repos/zdict/scripts/zdict", line 4, in <module>
    zdict.main()
  File "/Users/cychih/bin/.repos/zdict/zdict/zdict.py", line 302, in main
    args = set_args(args)
  File "/Users/cychih/bin/.repos/zdict/zdict/zdict.py", line 162, in set_args
    print('{}: {}'.format(provider, dictionary_map[provider]().title))
TypeError: __init__() missing 1 required positional argument: 'args'
```