### PR TITLE
Interactive mode crashes due to gnureadline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ install_requirements = parse_requirements(
 )
 install_requires = [str(ir.req) for ir in install_requirements]
 
-if sys.platform == 'darwin':
+if sys.platform == 'darwin' and sys.version_info <= (3, 5):
     install_requires.append('gnureadline==6.3.3')
 
 

--- a/zdict/tests/test_utils.py
+++ b/zdict/tests/test_utils.py
@@ -72,7 +72,8 @@ def test_platform_readline():
 
     with patch.object(sys, 'platform', new='darwin'):
         readline = import_readline()
-        assert readline.__name__ == 'gnureadline'
+        expect = 'gnureadline' if sys.version_info <= (3, 5) else 'readline'
+        assert readline.__name__ == expect
 
     with patch.object(sys, 'platform', new='foo'):
         readline = import_readline()

--- a/zdict/utils.py
+++ b/zdict/utils.py
@@ -89,7 +89,7 @@ class Color(metaclass=ColorConst):
 
 
 def import_readline():
-    if sys.platform == 'darwin':
+    if sys.platform == 'darwin' and sys.version_info <= (3, 5):
         import gnureadline as readline
     else:
         import readline


### PR DESCRIPTION
Environment: macOS 10.12.2
Python version: 3.6.0 (installed via homebrew)

The interactive mode does not work on my Mac. Every time when I type a word after the input prompt and then hit the Enter, zdict just crashes unexpectedly.

```
 ~ $ zdict
[zDict]: hello
Python(25299,0x7fffc83e63c0) malloc: *** error for object 0x10a9c0f00: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
[1]    25299 abort      zdict
```

After some investigation, I found that even `from zdict import zdict` single line also breaks the functionality of `input()` in Python interpreter. The root cause is that in Darwin, `gnureadline` is imported as `readline` in `utils.py`, and once the package is imported, the built-in function `input()` crashes all the time.

```
def import_readline():
    if sys.platform == 'darwin':
        import gnureadline as readline
    else:
        import readline
    return readline


readline = import_readline()   # this line is executed during import...
```

I'm curious about why we need gnureadline. Even I replace it with `readline`, the completer still works on macOS, and the interactive mode doesn't crash anymore. Thanks.