### PR TITLE
[travis] enable macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,37 @@
 language: python
 
-python:
-    - "3.4"
-    - "3.5"
-    - "3.5.1"
-    - "3.6"
-    - "nightly"
+matrix:
+    include:
+        - os: linux
+          python: 3.4
+        - os: linux
+          python: 3.5
+        - os: linux
+          python: 3.6
+        - os: linux
+          python: nightly
+
+        # Python runtime is not yet available on OS X
+        # https://github.com/travis-ci/travis-ci/issues/2312
+        - os: osx
+          language: generic
+          env: PYTHON_VERSION=3.4.6
+        - os: osx
+          language: generic
+          env: PYTHON_VERSION=3.5.3
+        - os: osx
+          language: generic
+          env: PYTHON_VERSION=3.6.0
+
+    allow_failures:
+        - python: "nightly"
+        - os: osx
+          language: generic
+          env: PYTHON_VERSION=3.4.6
+
+before_install:
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sh ci/install_python_for_osx.sh; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then source ~/venv/bin/activate; fi
 
 install:
     - "pip install -U pip"
@@ -23,11 +49,6 @@ notifications:
     webhooks:
         urls:
             - https://webhooks.gitter.im/e/7498c1d7f0e50c212e1a
-
-matrix:
-    allow_failures:
-        - python: "nightly"
-        - python: "3.5"  # maybe there is a bug of sqlite3 in 3.5.0
 
 deploy:
     provider: pypi

--- a/ci/install_python_for_osx.sh
+++ b/ci/install_python_for_osx.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/sh
+
+curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
+~/.pyenv/bin/pyenv install $PYTHON_VERSION
+~/.pyenv/versions/$PYTHON_VERSION/bin/python3 --version
+~/.pyenv/versions/$PYTHON_VERSION/bin/python3 -m venv ~/venv


### PR DESCRIPTION
This will enable macOS on Travis CI.

Because Travis CI does not support "macOS + Python" 💩 , I choose the generic language option and install specific python version by [pyenv](https://github.com/yyuu/pyenv). (The Python 3.4.6 on macOS on Travis CI failed with strange problem, so marked as allow failure 💩)

PS. the Travis CI's macOS support for Open Source project will wait for a long time before execution 😞 .

PPS. the tests doesn't discover the issues like #111, there is platform different between our users' and Travis CI's macOS, or maybe we lack some testing.

Related: #111 