### PR TITLE
[#108] add Taiwanese Moe Dict

### DIFF
--- a/zdict/dictionaries/moe.py
+++ b/zdict/dictionaries/moe.py
@@ -1,4 +1,5 @@
 import json
+import unicodedata  # to detect Unicode category
 
 from zdict.dictionary import DictBase
 from zdict.exceptions import QueryError, NotFoundError
@@ -82,6 +83,105 @@ class MoeDict(DictBase):
                     )
 
                 print()
+
+    def query(self, word: str):
+        try:
+            content = self._get_raw(word)
+        except QueryError as exception:
+            raise NotFoundError(exception.word)
+
+        record = Record(
+                    word=word,
+                    content=content,
+                    source=self.provider,
+                 )
+
+        return record
+
+
+def is_other_format(char):
+    return unicodedata.category(char) != 'Cf'
+
+
+def remove_cf(data):
+    return ''.join(filter(is_other_format, data))
+
+
+def clean(data, clean_cf=False):
+    '''
+    Clean the word segmentation
+
+    remove "`~" and things in Unicode 'Cf' category
+    '''
+    data = data.translate(str.maketrans('', '', '`~'))
+    if clean_cf:
+        return remove_cf(data)
+    else:
+        return data
+
+
+class MoeDictTaiwanese(DictBase):
+
+    API = 'https://www.moedict.tw/t/{word}.json'
+
+    @property
+    def provider(self):
+        return 'moe-taiwanese'
+
+    @property
+    def title(self):
+        return '萌典（臺）'
+
+    def _get_url(self, word) -> str:
+        return self.API.format(word=word)
+
+    def show(self, record: Record):
+        content = json.loads(record.content)
+
+        # print word
+        self.color.print(clean(content.get('t', '')), 'yellow')
+
+        for word in content.get('h', ''):
+
+            # print pronounce
+            for key, display in (
+                # TODO: where is bopomofo ?
+                ('T', '臺羅拼音'),      # Tailo
+            ):
+                self.color.print(display, end='')
+                self.color.print(
+                    '[' + word.get(key, '') + ']',
+                    'lwhite',
+                    end=' ',
+                )
+
+            print()
+            print()
+
+            # print explain
+            for count, explain in enumerate(word.get('d', '')):
+
+                self.color.print('{order}. '.format(order=count+1), end='')
+                type = clean(explain.get('type', ''))
+                if type:
+                    self.color.print(
+                        '[' + type + ']',
+                        'lgreen',
+                        end=' ',
+                    )
+
+                self.color.print(clean(explain.get('f', '')), end='')
+
+                for example in explain.get('e', ''):
+                    self.color.print(
+                        clean(example, True),
+                        'indigo',
+                        indent=2,
+                    )
+
+                print()
+
+            print()
 
     def query(self, word: str):
         try:

--- a/zdict/tests/dictionaries/test_moe.py
+++ b/zdict/tests/dictionaries/test_moe.py
@@ -87,7 +87,9 @@ class TestMoeDictTaiwanese:
     def test_query_normal(self, Record):
         self.dict._get_raw = Mock(return_value='{}')
         self.dict.query('木耳')
-        Record.assert_called_with(word='木耳', content='{}', source='moe-taiwanese')
+        Record.assert_called_with(word='木耳',
+                                  content='{}',
+                                  source='moe-taiwanese')
 
     def test_show(self):
         content = '''
@@ -96,7 +98,7 @@ class TestMoeDictTaiwanese:
                 "T": "bo̍k-ní",
                 "_": "928",
                 "d": [{
-                    "f": "蕈`菇~`類~。`生長~`在~`朽~`腐~`的~`樹~`幹~`上~，`成~`片~`狀~，`一邊~`黏~`在~`腐~`木~`上~，`表面~`向~`上~`突出~，菌`絲~`體~`生長~`後~，`生~`子~`實體~，`形狀~`長~`得~`像~`人~`的~`耳~朵，`徑~`大約~`一~`公~`寸~，`內面~`平~`滑~，`呈現~`暗~褐`色~，`外面~`有~`柔軟~`的~`短~`毛~，`呈~`淡~褐`色~。`可以~`供~`食用~。",
+                    "f": "蕈`菇~`類~。`生長~`在~`朽~`腐~`的~`樹~`幹~`上~ ...",
                     "type": "`名~"
                 }]
             }],


### PR DESCRIPTION
The Taiwanese Moe Dict's API is here: https://github.com/audreyt/moedict-webkit#5-閩南語-t

Currently, I just implement another new class, since this is the easiest way to implement this feature now.

If we want additional arguments for "dictionary class" to choose the "queried dictionary", we should open another issue to discuss and implement.

![moe-taiwan](https://cloud.githubusercontent.com/assets/2716047/22259292/b23f9b8a-e29f-11e6-933d-ada88a96d903.png)

BTW, it looks like we miss some information with current API ...
Here is the web version, we miss something ...
![moe-web](https://cloud.githubusercontent.com/assets/2716047/22259352/f625a182-e29f-11e6-9082-81f151786513.png)
