### PR TITLE
[zdict-0.9.7]

### DIFF
--- a/zdict/constants.py
+++ b/zdict/constants.py
@@ -1,7 +1,7 @@
 import os
 
 
-VERSION = '0.9.6'
+VERSION = '0.9.7'
 
 BASE_DIR_NAME = '.zdict'
 BASE_DIR = os.path.join(os.getenv('HOME'), BASE_DIR_NAME)


### PR DESCRIPTION
+ [#103] Fix the bug during getting the mp3 file url in Yahoo! dictionary.
+ [#112] Add Python 3.6 into Travis CI testing.
+ [#113] Enable macOS tesing env on Travis CI testing.
+ [#114] Add Taiwanese Moe Dict.
+ [#119] Fix Peewee connection for [the backwards-incompatible changes since Peewee 2.8.7](https://github.com/coleifer/peewee/blob/master/CHANGELOG.md#backwards-incompatible-changes).