### PR TITLE
[#98] Install `locales` for using `locale-gen` for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,10 @@ FROM ubuntu:16.04
 # Set the locale
 RUN apt-get clean && apt-get update && apt-get install -y locales
 RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"
 
 # Install Python3 & pip3
-RUN apt-get install -y python3
-RUN apt-get install -y python3-pip
+RUN apt-get install -y python3 python3-pip
 RUN pip3 install --upgrade pip
 
 # Install zdict

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:16.04
 
 # Set the locale
+RUN apt-get clean && apt-get update && apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 # Install Python3 & pip3
-RUN apt-get update
 RUN apt-get install -y python3
 RUN apt-get install -y python3-pip
 RUN pip3 install --upgrade pip


### PR DESCRIPTION
ref: #98

To fix the error `The command '/bin/sh -c locale-gen en_US.UTF-8' returned a non-zero code: 127`