### PR TITLE
[#148] Fix the bug when getting user home dir on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python33-x64"
+      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+
+install:
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\python.exe -m pip install wheel"
+
+build: off
+
+test_script:
+  # Put your test command here.
+  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
+  # you can remove "build.cmd" from the front of the command, as it's
+  # only needed to support those cases.
+  # Note that you must use the environment variable %PYTHON% to refer to
+  # the interpreter you're using - Appveyor does not do anything special
+  # to put the Python version you want to use on PATH.
+  - "build.cmd %PYTHON%\\python.exe setup.py test"
+
+after_test:
+  # This step builds your wheels.
+  # Again, you only need build.cmd if you're building C extensions for
+  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
+  # interpreter
+  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  - path: dist\*
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,10 @@ environment:
 
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
-    # The list here is complete (excluding Python 2.6, which
-    # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python33-x64"
       DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python34-x64"
@@ -23,6 +19,13 @@ install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
 
+  - "%PYTHON%\\python.exe -m pip install -U setuptools pip pytest"
+  - "%PYTHON%\\python.exe -m pip install ."
+
+  # Show all installed Python packages version
+  - "%PYTHON%\\python.exe -m pip freeze"
+
+
 build: off
 
 test_script:
@@ -33,14 +36,14 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python version you want to use on PATH.
-  - "build.cmd %PYTHON%\\python.exe setup.py test"
+  - "%PYTHON%\\python.exe setup.py test"
 
 after_test:
   # This step builds your wheels.
   # Again, you only need build.cmd if you're building C extensions for
   # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
   # interpreter
-  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+  - "%PYTHON%\\python.exe setup.py bdist_wheel"
 
 artifacts:
   # bdist_wheel puts your built wheel in the dist directory

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,10 @@ def get_test_req():
     )
     test_requires = [str(tr.req) for tr in test_requirements]
 
-    if not sys.platform.startswith('freebsd'):
+    if sys.platform == 'darwin' and sys.version_info <= (3, 5):
         test_requires.append('gnureadline==6.3.3')
+    elif sys.platform == 'win32' or sys.platform == 'cygwin':
+        test_requires.append('pyreadline==2.1')
 
     return test_requires
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ install_requires = [str(ir.req) for ir in install_requirements]
 
 if sys.platform == 'darwin' and sys.version_info <= (3, 5):
     install_requires.append('gnureadline==6.3.3')
+elif sys.platform == 'win32' or sys.platform == 'cygwin':
+    install_requires.append('pyreadline==2.1')
 
 
 setup(

--- a/zdict/constants.py
+++ b/zdict/constants.py
@@ -4,7 +4,7 @@ import os
 VERSION = '0.10.1'
 
 BASE_DIR_NAME = '.zdict'
-BASE_DIR = os.path.join(os.getenv('HOME'), BASE_DIR_NAME)
+BASE_DIR = os.path.join(os.path.expanduser("~"), BASE_DIR_NAME)
 
 DB_NAME = 'zdict.db'
 DB_FILE = os.path.join(BASE_DIR, DB_NAME)

--- a/zdict/tests/test_utils.py
+++ b/zdict/tests/test_utils.py
@@ -66,14 +66,8 @@ def test_platform_readline():
     '''
     Check the imported readline module on different platforms
     '''
-    with patch.object(sys, 'platform', new='linux'):
-        readline = import_readline()
-        assert readline.__name__ == 'readline'
-
-    with patch.object(sys, 'platform', new='darwin'):
-        readline = import_readline()
-        expect = 'gnureadline' if sys.version_info <= (3, 5) else 'readline'
-        assert readline.__name__ == expect
+    readline = import_readline()
+    assert readline.__name__ == 'readline'
 
     with patch.object(sys, 'platform', new='foo'):
         readline = import_readline()

--- a/zdict/utils.py
+++ b/zdict/utils.py
@@ -91,6 +91,8 @@ class Color(metaclass=ColorConst):
 def import_readline():
     if sys.platform == 'darwin' and sys.version_info <= (3, 5):
         import gnureadline as readline
+    elif sys.platform == 'win32' or sys.platform == 'cygwin':
+        import pyreadline as readline
     else:
         import readline
     return readline


### PR DESCRIPTION
Use `os.path.expanduser` instead of using `os.path.join` directly,
since the formmer is better handled for Windows.

<https://docs.python.org/3/library/os.path.html#os.path.expanduser>

ref: GitHub issue #148 