### PR TITLE
add oxford dictionary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ Screenshots
 
 .. image:: http://i.imgur.com/VkPEfKh.png
 
-To use this source, you should first `apply <https://developer.oxforddictionaries.com/>`_ an API key and place it under `~/.zdict/oxford.key` in the format::
+To use this source, you should first `apply <https://developer.oxforddictionaries.com/>`_ an API key and place it under ``~/.zdict/oxford.key`` in the format::
 
     app_id, app_key
 

--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,16 @@ Screenshots
 .. image:: https://user-images.githubusercontent.com/2716047/29741879-ca1a3826-8a3a-11e7-9701-4a7e9a15971a.png
 
 
+`Oxford Dictionary <https://en.oxforddictionaries.com/>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. image:: http://i.imgur.com/VkPEfKh.png
+
+To use this source, you should first `apply <https://developer.oxforddictionaries.com/>`_ an API key and place it under `~/.zdict/oxford.key` in the format::
+
+    app_id, app_key
+
+
 Development & Contributing
 ---------------------------
 

--- a/zdict/dictionaries/oxford.py
+++ b/zdict/dictionaries/oxford.py
@@ -4,7 +4,7 @@ import re
 
 from zdict.constants import BASE_DIR
 from zdict.dictionary import DictBase
-from zdict.exceptions import NotFoundError, QueryError, ApiKeyError
+from zdict.exceptions import NotFoundError, QueryError, APIKeyError
 from zdict.models import Record
 
 
@@ -148,14 +148,14 @@ class OxfordDictionary(DictBase):
         key_file = os.path.join(BASE_DIR, KEY_FILE)
 
         if not os.path.exists(key_file):
-            raise ApiKeyError('Oxford: API key not found.')
+            raise APIKeyError('Oxford: API key not found.')
 
         with open(key_file) as fp:
             keys = fp.read()
 
         keys = re.sub('\s', '', keys).split(',')
         if len(keys) != 2:
-            raise ApiKeyError('Oxford: API key file format not correct.')
+            raise APIKeyError('Oxford: API key file format not correct.')
 
         return keys
 

--- a/zdict/dictionaries/oxford.py
+++ b/zdict/dictionaries/oxford.py
@@ -126,7 +126,7 @@ class OxfordDictionary(DictBase):
             self.color.print(example['text'], 'indigo', indent=indent+2)
 
         # subsenses
-        if 'subsenses' in sense:
+        if self.args.verbose and 'subsenses' in sense:
             for idx, subsense in enumerate(sense['subsenses'], 1):
                 line_prefix = '{prefix}{idx}.'.format(prefix=prefix, idx=idx)
                 self._show_sense(subsense, line_prefix, indent=indent + 1)

--- a/zdict/dictionaries/oxford.py
+++ b/zdict/dictionaries/oxford.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 from zdict.constants import BASE_DIR
 from zdict.dictionary import DictBase
@@ -8,37 +9,6 @@ from zdict.models import Record
 
 
 KEY_FILE = 'oxford.key'
-
-
-class OxfordApiKeyStore(object):
-    """
-    The Oxford dictionary should use the API key to query.
-    But the request limit is too low to share the key for all.
-
-    The API key should placed in ``KEY_FILE`` in the ``~/.zdict`` with the
-    format:
-    .. code::
-        app_id,app_key
-
-    .. note::
-        request limit: per minute is 60, per month is 3000.
-    """
-
-    def __init__(self):
-        key_file = os.path.join(BASE_DIR, KEY_FILE)
-
-        if not os.path.exists(key_file):
-            raise ApiKeyError('Oxford: API key not found.')
-
-        with open(key_file) as fp:
-            keys = fp.read()
-
-        keys = keys.strip().replace(' ', '').split(',')
-        if len(keys) != 2:
-            raise ApiKeyError('Oxford: API key file format not correct.')
-
-        self.id = keys[0]
-        self.key = keys[1]
 
 
 class OxfordDictionary(DictBase):
@@ -161,12 +131,40 @@ class OxfordDictionary(DictBase):
                 line_prefix = '{prefix}{idx}.'.format(prefix=prefix, idx=idx)
                 self._show_sense(subsense, line_prefix, indent=indent + 1)
 
+    @staticmethod
+    def _get_app_key():
+        """
+        Get the app id & key for query
+
+        .. note:: app key storage
+            The API key should placed in ``KEY_FILE`` in the ``~/.zdict`` with
+            the format::
+
+                app_id,app_key
+
+        .. note:: request limit
+            request limit: per minute is 60, per month is 3000.
+        """
+        key_file = os.path.join(BASE_DIR, KEY_FILE)
+
+        if not os.path.exists(key_file):
+            raise ApiKeyError('Oxford: API key not found.')
+
+        with open(key_file) as fp:
+            keys = fp.read()
+
+        keys = re.sub('\s', '', keys).split(',')
+        if len(keys) != 2:
+            raise ApiKeyError('Oxford: API key file format not correct.')
+
+        return keys
+
     def query(self, word: str):
-        app_key = OxfordApiKeyStore()
         try:
+            app_id, app_key = self._get_app_key()
             content = self._get_raw(word, headers={
-                'app_id': app_key.id,
-                'app_key': app_key.key
+                'app_id': app_id,
+                'app_key': app_key
             })
         except QueryError as exception:
             msg = self.status_code.get(exception.status_code,

--- a/zdict/dictionaries/oxford.py
+++ b/zdict/dictionaries/oxford.py
@@ -144,7 +144,15 @@ class OxfordDictionary(DictBase):
             request limit: per minute is 60, per month is 3000.
         """
         if not os.path.exists(self.KEY_FILE):
-            self._show_instruction()
+            self.color.print('You can get an API key by the following steps:',
+                             'yellow')
+            print('1. Register a developer account at '
+                  'https://developer.oxforddictionaries.com/')
+            print('2. Get the application id & keys in the `credentials` page')
+            print('3. Paste the API key at `{key_file}` in the foramt:'.format(
+                key_file=self.KEY_FILE
+            ))
+            print('     app_id, app_key')
             raise APIKeyError('Oxford: API key not found')
 
         with open(self.KEY_FILE) as fp:
@@ -152,24 +160,11 @@ class OxfordDictionary(DictBase):
 
         keys = re.sub('\s', '', keys).split(',')
         if len(keys) != 2:
-            self._show_instruction()
+            print('The API key should be placed in the format:')
+            print('     app_id, app_key')
             raise APIKeyError('Oxford: API key file format not correct.')
 
         return keys
-
-    def _show_instruction(self):
-        """
-        Show the instruction to get API key
-        """
-        self.color.print('You can get an API key by the following steps:',
-                         'yellow')
-        print('1. Register a developer account at '
-              'https://developer.oxforddictionaries.com/')
-        print('2. Get the application id & keys in the `credentials` page')
-        print('3. Paste the API key at `{key_file}` in the foramt:'.format(
-            key_file=self.KEY_FILE
-        ))
-        print('     app_id, app_key')
 
     def query(self, word: str):
         try:

--- a/zdict/dictionaries/oxford.py
+++ b/zdict/dictionaries/oxford.py
@@ -15,7 +15,8 @@ class OxfordApiKeyStore(object):
     The Oxford dictionary should use the API key to query.
     But the request limit is too low to share the key for all.
 
-    The API key should placed in ``KEY_FILE`` in the ``~/.zdict`` with the format:
+    The API key should placed in ``KEY_FILE`` in the ``~/.zdict`` with the
+    format:
     .. code::
         app_id,app_key
 
@@ -32,7 +33,7 @@ class OxfordApiKeyStore(object):
         with open(key_file) as fp:
             keys = fp.read()
 
-        keys = keys.strip().replace(' ','').split(',')
+        keys = keys.strip().replace(' ', '').split(',')
         if len(keys) != 2:
             raise ApiKeyError('Oxford: API key file format not correct.')
 

--- a/zdict/dictionaries/oxford.py
+++ b/zdict/dictionaries/oxford.py
@@ -50,11 +50,11 @@ class OxfordDictionary(DictBase):
     def show(self, record: Record):
         content = json.loads(record.content)
 
-        # word
-        self.color.print(record.word, 'lyellow')
-
         # results
         for headword in content['results']:
+            # word
+            self.color.print(headword['word'], 'lyellow')
+
             for lex_ent in headword['lexicalEntries']:
                 # lexical category
                 print()

--- a/zdict/dictionaries/oxford.py
+++ b/zdict/dictionaries/oxford.py
@@ -1,0 +1,132 @@
+import json
+
+from zdict.dictionary import DictBase
+from zdict.exceptions import NotFoundError, QueryError
+from zdict.models import Record
+
+
+# The request limit per minute is 60
+# The monthly limit is 3,000 requests
+API_ID = 'YOUR_API_ID'
+API_KEY = 'YOUR_API_KEY'
+
+
+class OxfordDictionary(DictBase):
+    """
+    Docs:
+
+    * https://developer.oxforddictionaries.com/documentation/
+    """
+
+    API = 'https://od-api.oxforddictionaries.com/api/v1/entries/en/{word}'
+
+    @property
+    def provider(self):
+        return 'oxford'
+
+    @property
+    def title(self):
+        return 'Oxford Dictionary'
+
+    def _get_url(self, word) -> str:
+        return self.API.format(word=word.lower())
+
+    def show(self, record: Record):
+        content = json.loads(record.content)
+
+        # word
+        self.color.print(record.word, 'lyellow')
+
+        # results
+        for headword in content['results']:
+            for lex_ent in headword['lexicalEntries']:
+                # lexical category
+                print()
+                self.color.print(lex_ent['lexicalCategory'], 'lred', end='')
+
+                # pronunciation
+                if 'pronunciations' in lex_ent:
+                    pronunciations = [
+                        '/' + pronun['phoneticSpelling'] + '/'
+                        for pronun in lex_ent['pronunciations']
+                    ]
+                    pronunciations_str = '  '.join(pronunciations)
+                    self.color.print('  ' + pronunciations_str)
+                else:
+                    print()
+
+                # entry
+                idx = 1
+                for entry in lex_ent['entries']:
+                    for sense in entry['senses']:
+                        line_prefix = '{idx}.'.format(idx=idx)
+                        self._show_sense(sense, line_prefix)
+                        idx += 1
+
+        print()
+
+    def _show_sense(self, sense: dict, prefix='', indent=1):
+        print()
+        self.color.print(prefix, end=' ', indent=indent)
+
+        # regions
+        if 'regions' in sense:
+            regions_str = ', '.join(sense['regions'])
+            regions_str = '(' + regions_str + ')'
+            self.color.print(regions_str, 'yellow', end=' ')
+
+        # register
+        if 'registers' in sense:
+            registers_str = ', '.join(sense['registers'])
+            self.color.print(registers_str, 'red', end=' ')
+
+        # domain
+        if 'domains' in sense:
+            domains_str = ', '.join(sense['domains'])
+            domains_str = '(' + domains_str + ') '
+            self.color.print(domains_str, 'green', end='')
+
+        # notes
+        if 'notes' in sense:
+            notes = [note['text'] for note in sense['notes']]
+            notes_str = ', '.join(notes)
+            notes_str = '[' + notes_str + '] '
+            self.color.print(notes_str, 'magenta', end='')
+
+        # definition
+        if 'definitions' in sense:
+            definition_str = '. '.join(sense['definitions'])
+            print(definition_str)
+
+        # cross ref
+        if 'crossReferenceMarkers' in sense:
+            xref_marker_str = '. '.join(sense['crossReferenceMarkers'])
+            print(xref_marker_str)
+
+        # example
+        for example in sense.get('examples', []):
+            print()
+            print(' ' * (indent + 1), end='  ')
+            self.color.print(example['text'], 'indigo', indent=indent+2)
+
+        # subsenses
+        if 'subsenses' in sense:
+            for idx, subsense in enumerate(sense['subsenses'], 1):
+                line_prefix = '{prefix}{idx}.'.format(prefix=prefix, idx=idx)
+                self._show_sense(subsense, line_prefix, indent=indent + 1)
+
+    def query(self, word: str):
+        try:
+            content = self._get_raw(word, headers={
+                'app_id': API_ID,
+                'app_key': API_KEY
+            })
+        except QueryError as exception:
+            raise NotFoundError(exception.word)
+
+        record = Record(
+            word=word,
+            content=content,
+            source=self.provider,
+        )
+        return record

--- a/zdict/dictionaries/oxford.py
+++ b/zdict/dictionaries/oxford.py
@@ -50,6 +50,22 @@ class OxfordDictionary(DictBase):
 
     API = 'https://od-api.oxforddictionaries.com/api/v1/entries/en/{word}'
 
+    # https://developer.oxforddictionaries.com/documentation/response-codes
+    status_code = {
+        200: 'Success!',
+        400: 'The request was invalid or cannot be otherwise served.',
+        403: 'The request failed due to invalid credentials.',
+        404: 'No entry is found.',
+        500: 'Something is broken. Please contact the Oxford Dictionaries '
+             'API team to investigate.',
+        502: 'Oxford Dictionaries API is down or being upgraded.',
+        503: 'The Oxford Dictionaries API servers are up, but overloaded '
+             'with requests. Please try again later.',
+        504: 'The Oxford Dictionaries API servers are up, but the request '
+             'couldn’t be serviced due to some failure within our stack. '
+             'Please try again later.'
+    }
+
     @property
     def provider(self):
         return 'oxford'
@@ -153,6 +169,9 @@ class OxfordDictionary(DictBase):
                 'app_key': app_key.key
             })
         except QueryError as exception:
+            msg = self.status_code.get(exception.status_code,
+                                       'Some bad thing happened')
+            self.color.print('Oxford: ' + msg, 'red')
             raise NotFoundError(exception.word)
 
         record = Record(

--- a/zdict/dictionary.py
+++ b/zdict/dictionary.py
@@ -135,6 +135,9 @@ class DictBase(metaclass=abc.ABCMeta):
         except exceptions.TimeoutError as e:
             self.color.print(e, 'red')
             print()
+        except exceptions.ApiKeyError as e:
+            self.color.print(e, 'red')
+            print()
         except exceptions.NotFoundError as e:
             self.color.print(e, 'yellow')
             print()

--- a/zdict/dictionary.py
+++ b/zdict/dictionary.py
@@ -143,7 +143,7 @@ class DictBase(metaclass=abc.ABCMeta):
             self.show(record)
             return
 
-    def _get_raw(self, word: str) -> str:
+    def _get_raw(self, word: str, **kwargs) -> str:
         '''
         Get raw data from http request
 
@@ -152,7 +152,7 @@ class DictBase(metaclass=abc.ABCMeta):
 
         try:
             res = requests.get(
-                self._get_url(word), timeout=self.args.query_timeout
+                self._get_url(word), timeout=self.args.query_timeout, **kwargs
             )
         except requests.exceptions.ReadTimeout as e:
             raise exceptions.TimeoutError()

--- a/zdict/dictionary.py
+++ b/zdict/dictionary.py
@@ -135,7 +135,7 @@ class DictBase(metaclass=abc.ABCMeta):
         except exceptions.TimeoutError as e:
             self.color.print(e, 'red')
             print()
-        except exceptions.ApiKeyError as e:
+        except exceptions.APIKeyError as e:
             self.color.print(e, 'red')
             print()
         except exceptions.NotFoundError as e:

--- a/zdict/exceptions.py
+++ b/zdict/exceptions.py
@@ -40,7 +40,7 @@ class UnexpectedError(Exception):
         )
 
 
-class ApiKeyError(Exception):
+class APIKeyError(Exception):
     def __init__(self, msg):
         self.msg = msg
 

--- a/zdict/exceptions.py
+++ b/zdict/exceptions.py
@@ -38,3 +38,11 @@ class UnexpectedError(Exception):
                 '',
             ))
         )
+
+
+class ApiKeyError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg

--- a/zdict/tests/dictionaries/test_oxford.py
+++ b/zdict/tests/dictionaries/test_oxford.py
@@ -33,6 +33,9 @@ class TestOxfordDictionary:
         assert app_id == 'test_app_id'
         assert app_key == 'test_app_key'
 
+    def test__show_instruction(self):
+        self.dict._show_instruction()
+
     def test_query_notfound(self):
         self.dict._get_raw = Mock(side_effect=QueryError('mock', 404))
         self.dict._get_app_key = Mock(return_value=('id', 'key'))

--- a/zdict/tests/dictionaries/test_oxford.py
+++ b/zdict/tests/dictionaries/test_oxford.py
@@ -33,9 +33,6 @@ class TestOxfordDictionary:
         assert app_id == 'test_app_id'
         assert app_key == 'test_app_key'
 
-    def test__show_instruction(self):
-        self.dict._show_instruction()
-
     def test_query_notfound(self):
         self.dict._get_raw = Mock(side_effect=QueryError('mock', 404))
         self.dict._get_app_key = Mock(return_value=('id', 'key'))

--- a/zdict/tests/dictionaries/test_oxford.py
+++ b/zdict/tests/dictionaries/test_oxford.py
@@ -1,0 +1,357 @@
+from pytest import raises
+from unittest.mock import Mock, mock_open, patch
+
+from zdict.dictionaries.oxford import OxfordDictionary
+from zdict.exceptions import NotFoundError, QueryError
+from zdict.models import Record
+from zdict.zdict import get_args
+
+
+class TestOxfordDictionary:
+    def setup_method(self, method):
+        self.dict = OxfordDictionary(get_args())
+
+    def teardown_method(self, method):
+        del self.dict
+
+    def test_provider(self):
+        assert self.dict.provider == 'oxford'
+
+    def test__get_url(self):
+        uri = 'https://od-api.oxforddictionaries.com/api/v1/entries/en/mock'
+        assert self.dict._get_url('mock') == uri
+
+    def test__get_app_key(self):
+        key_file_data = """
+            test_app_id,
+            test_app_key """
+        key_file = mock_open(read_data=key_file_data)
+
+        with patch('zdict.dictionaries.oxford.open', key_file):
+            app_id, app_key = self.dict._get_app_key()
+
+        assert app_id == 'test_app_id'
+        assert app_key == 'test_app_key'
+
+    def test_query_notfound(self):
+        self.dict._get_raw = Mock(side_effect=QueryError('mock', 404))
+        self.dict._get_app_key = Mock(return_value=('id', 'key'))
+
+        with raises(NotFoundError):
+            self.dict.query('mock')
+
+        self.dict._get_raw.assert_called_with('mock', headers={
+            'app_id': 'id',
+            'app_key': 'key'
+        })
+
+    @patch('zdict.dictionaries.oxford.Record')
+    def test_query_normal(self, Record):
+        self.dict._get_raw = Mock(return_value=SAMPLE_RESPONSE)
+        self.dict._get_app_key = Mock(return_value=('id', 'key'))
+
+        self.dict.query('string')
+
+        Record.assert_called_with(word='string',
+                                  content=SAMPLE_RESPONSE,
+                                  source='oxford')
+
+    def test_show(self):
+        r = Record(word='string',
+                   content=SAMPLE_RESPONSE,
+                   source=self.dict.provider)
+        self.dict.show(r)
+
+
+# the sample response copied from the official website
+SAMPLE_RESPONSE = """
+{
+  "metadata": {},
+  "results": [
+    {
+      "id": "string",
+      "language": "string",
+      "lexicalEntries": [
+        {
+          "derivativeOf": [
+            {
+              "domains": [
+                "string"
+              ],
+              "id": "string",
+              "language": "string",
+              "regions": [
+                "string"
+              ],
+              "registers": [
+                "string"
+              ],
+              "text": "string"
+            }
+          ],
+          "derivatives": [
+            {
+              "domains": [
+                "string"
+              ],
+              "id": "string",
+              "language": "string",
+              "regions": [
+                "string"
+              ],
+              "registers": [
+                "string"
+              ],
+              "text": "string"
+            }
+          ],
+          "entries": [
+            {
+              "etymologies": [
+                "string"
+              ],
+              "grammaticalFeatures": [
+                {
+                  "text": "string",
+                  "type": "string"
+                }
+              ],
+              "homographNumber": "string",
+              "notes": [
+                {
+                  "id": "string",
+                  "text": "string",
+                  "type": "string"
+                }
+              ],
+              "pronunciations": [
+                {
+                  "audioFile": "string",
+                  "dialects": [
+                    "string"
+                  ],
+                  "phoneticNotation": "string",
+                  "phoneticSpelling": "string",
+                  "regions": [
+                    "string"
+                  ]
+                }
+              ],
+              "senses": [
+                {
+                  "crossReferenceMarkers": [
+                    "string"
+                  ],
+                  "crossReferences": [
+                    {
+                      "id": "string",
+                      "text": "string",
+                      "type": "string"
+                    }
+                  ],
+                  "definitions": [
+                    "string"
+                  ],
+                  "domains": [
+                    "string"
+                  ],
+                  "examples": [
+                    {
+                      "definitions": [
+                        "string"
+                      ],
+                      "domains": [
+                        "string"
+                      ],
+                      "notes": [
+                        {
+                          "id": "string",
+                          "text": "string",
+                          "type": "string"
+                        }
+                      ],
+                      "regions": [
+                        "string"
+                      ],
+                      "registers": [
+                        "string"
+                      ],
+                      "senseIds": [
+                        "string"
+                      ],
+                      "text": "string",
+                      "translations": [
+                        {
+                          "domains": [
+                            "string"
+                          ],
+                          "grammaticalFeatures": [
+                            {
+                              "text": "string",
+                              "type": "string"
+                            }
+                          ],
+                          "language": "string",
+                          "notes": [
+                            {
+                              "id": "string",
+                              "text": "string",
+                              "type": "string"
+                            }
+                          ],
+                          "regions": [
+                            "string"
+                          ],
+                          "registers": [
+                            "string"
+                          ],
+                          "text": "string"
+                        }
+                      ]
+                    }
+                  ],
+                  "id": "string",
+                  "notes": [
+                    {
+                      "id": "string",
+                      "text": "string",
+                      "type": "string"
+                    }
+                  ],
+                  "pronunciations": [
+                    {
+                      "audioFile": "string",
+                      "dialects": [
+                        "string"
+                      ],
+                      "phoneticNotation": "string",
+                      "phoneticSpelling": "string",
+                      "regions": [
+                        "string"
+                      ]
+                    }
+                  ],
+                  "regions": [
+                    "string"
+                  ],
+                  "registers": [
+                    "string"
+                  ],
+                  "short_definitions": [
+                    "string"
+                  ],
+                  "subsenses": [
+                    {}
+                  ],
+                  "thesaurusLinks": [
+                    {
+                      "entry_id": "string",
+                      "sense_id": "string"
+                    }
+                  ],
+                  "translations": [
+                    {
+                      "domains": [
+                        "string"
+                      ],
+                      "grammaticalFeatures": [
+                        {
+                          "text": "string",
+                          "type": "string"
+                        }
+                      ],
+                      "language": "string",
+                      "notes": [
+                        {
+                          "id": "string",
+                          "text": "string",
+                          "type": "string"
+                        }
+                      ],
+                      "regions": [
+                        "string"
+                      ],
+                      "registers": [
+                        "string"
+                      ],
+                      "text": "string"
+                    }
+                  ],
+                  "variantForms": [
+                    {
+                      "regions": [
+                        "string"
+                      ],
+                      "text": "string"
+                    }
+                  ]
+                }
+              ],
+              "variantForms": [
+                {
+                  "regions": [
+                    "string"
+                  ],
+                  "text": "string"
+                }
+              ]
+            }
+          ],
+          "grammaticalFeatures": [
+            {
+              "text": "string",
+              "type": "string"
+            }
+          ],
+          "language": "string",
+          "lexicalCategory": "string",
+          "notes": [
+            {
+              "id": "string",
+              "text": "string",
+              "type": "string"
+            }
+          ],
+          "pronunciations": [
+            {
+              "audioFile": "string",
+              "dialects": [
+                "string"
+              ],
+              "phoneticNotation": "string",
+              "phoneticSpelling": "string",
+              "regions": [
+                "string"
+              ]
+            }
+          ],
+          "text": "string",
+          "variantForms": [
+            {
+              "regions": [
+                "string"
+              ],
+              "text": "string"
+            }
+          ]
+        }
+      ],
+      "pronunciations": [
+        {
+          "audioFile": "string",
+          "dialects": [
+            "string"
+          ],
+          "phoneticNotation": "string",
+          "phoneticSpelling": "string",
+          "regions": [
+            "string"
+          ]
+        }
+      ],
+      "type": "string",
+      "word": "string"
+    }
+  ]
+}
+"""

--- a/zdict/tests/dictionaries/test_oxford.py
+++ b/zdict/tests/dictionaries/test_oxford.py
@@ -21,13 +21,13 @@ class TestOxfordDictionary:
         uri = 'https://od-api.oxforddictionaries.com/api/v1/entries/en/mock'
         assert self.dict._get_url('mock') == uri
 
-    def test__get_app_key(self):
-        key_file_data = """
+    @patch('os.path.exists')
+    def test__get_app_key(self, exists):
+        key_file = mock_open(read_data="""
             test_app_id,
-            test_app_key """
-        key_file = mock_open(read_data=key_file_data)
+            test_app_key """)
 
-        with patch('zdict.dictionaries.oxford.open', key_file):
+        with patch('builtins.open', key_file):
             app_id, app_key = self.dict._get_app_key()
 
         assert app_id == 'test_app_id'


### PR DESCRIPTION
This PR adds the Oxford dictionary as the source.

**note**
+ it uses the request header to send the API key so I've changed the `_get_raw`
+ it reads the API key from `~/.zdict/oxford.key`. Maybe I should add some doc...

...and I haven't written test code for it, maybe I should apply a key for testing