### PR TITLE
Upgrade to v0.12.0

### DIFF
--- a/zdict/constants.py
+++ b/zdict/constants.py
@@ -1,7 +1,7 @@
 import os
 
 
-VERSION = '0.11.0'
+VERSION = '0.12.0'
 
 BASE_DIR_NAME = '.zdict'
 BASE_DIR = os.path.join(os.path.expanduser("~"), BASE_DIR_NAME)


### PR DESCRIPTION
* Upgrade OSX CI test version to CPython 3.4.8/3.5.5/3.6.4 (#198)
* Update pytest-flake8 to 1.0.0 (#200)
* Update pytest to 3.5.0 (#202)
* Update py to 1.5.3 (#201)
* Update peewee to 3.2.2 (#208)
* Update flake8 to 3.5.0 (#207)
* Update Travis CI setting (65a22dd, 7cfaa26, 0f94522)
* Add Oxford Dictionaries support (#209), thanks @tzing

Ref: https://github.com/zdict/zdict/compare/v0.11.0...f74cec4629d7f495f2285d2b15aa7be66cfd7523