### PR TITLE
Add wiktionary

### DIFF
--- a/zdict/dictionaries/wiktionary.py
+++ b/zdict/dictionaries/wiktionary.py
@@ -42,13 +42,13 @@ class WiktionaryDict(DictBase):
         content = json.loads(content)
 
         try:
-            # Get the first definition string from json.
+            # Get the first definition string from JSON.
             definition = content['en'][0]['definitions'][0]['definition']
         except KeyError as exception:
-            # API can return json that does not contain 'en' language.
+            # API can return JSON that does not contain 'en' language.
             raise NotFoundError(word)
         else:
-            # Clean the definition string from html tags.
+            # Clean the definition string from HTML tags.
             definition = BeautifulSoup(definition, "html.parser").text
             content = {}
             content['definition'] = definition

--- a/zdict/dictionaries/wiktionary.py
+++ b/zdict/dictionaries/wiktionary.py
@@ -3,7 +3,7 @@ import json
 from bs4 import BeautifulSoup
 
 from zdict.dictionary import DictBase
-from zdict.exceptions import NotFoundError
+from zdict.exceptions import NotFoundError, QueryError
 from zdict.models import Record
 
 
@@ -40,7 +40,10 @@ class WiktionaryDict(DictBase):
         )
 
     def query(self, word: str):
-        content = self._get_raw(word)
+        try:
+            content = self._get_raw(word)
+        except QueryError as exception:
+            raise NotFoundError(exception.word)
 
         record = Record(
             word=word,

--- a/zdict/dictionaries/wiktionary.py
+++ b/zdict/dictionaries/wiktionary.py
@@ -29,7 +29,7 @@ class WiktionaryDict(DictBase):
         definition = content['en'][0]['definitions'][0]['definition']
 
         # Clean the definition string from html tags.
-        definition = BeautifulSoup(definition, "lxml").text
+        definition = BeautifulSoup(definition, "html.parser").text
 
         # Render the output.
         self.color.print(record.word, 'yellow')

--- a/zdict/dictionaries/wiktionary.py
+++ b/zdict/dictionaries/wiktionary.py
@@ -1,0 +1,51 @@
+import json
+
+from bs4 import BeautifulSoup
+
+from zdict.dictionary import DictBase
+from zdict.exceptions import NotFoundError
+from zdict.models import Record
+
+
+class WiktionaryDict(DictBase):
+
+    API = 'https://en.wiktionary.org/api/rest_v1/page/definition/{word}'
+
+    @property
+    def provider(self):
+        return 'wiktionary'
+
+    @property
+    def title(self):
+        return 'Wiktionary'
+
+    def _get_url(self, word) -> str:
+        return self.API.format(word=word)
+
+    def show(self, record: Record):
+        content = json.loads(record.content)
+
+        # Get the first definition string from json.
+        definition = content['en'][0]['definitions'][0]['definition']
+
+        # Clean the definition string from html tags.
+        definition = BeautifulSoup(definition, "lxml").text
+
+        # Render the output.
+        self.color.print(record.word, 'yellow')
+        self.color.print(
+            definition,
+            'org',
+            indent=2,
+        )
+
+    def query(self, word: str):
+        content = self._get_raw(word)
+
+        record = Record(
+            word=word,
+            content=content,
+            source=self.provider,
+        )
+
+        return record

--- a/zdict/tests/dictionaries/test_wiktionary.py
+++ b/zdict/tests/dictionaries/test_wiktionary.py
@@ -31,38 +31,19 @@ class TestWiktionaryDict:
 
     @patch('zdict.dictionaries.wiktionary.Record')
     def test_query_normal(self, Record):
-        self.dict._get_raw = Mock(return_value='{"mock": true}')
+        content = '{"en":[{"definitions":[{"definition":"string"}]}]}'
+        self.dict._get_raw = Mock(return_value=content)
         self.dict.query('mock')
         Record.assert_called_with(
             word='mock',
-            content='{"mock": true}',
+            content='{"definition": "string"}',
             source='wiktionary'
         )
 
     def test_show(self):
-        content = '''
-        {
-           "en":[
-              {
-                 "partOfSpeech":"string",
-                 "language":"string",
-                 "definitions":[
-                    {
-                       "definition":"string",
-                       "parsedExamples":[
-                          {
-                             "example":"string"
-                          }
-                       ],
-                       "examples":[
-                          "string"
-                       ]
-                    }]
-                }]
-        }
-        '''
+        content = '{"definition": "string"}'
 
-        r = Record(word='string',
+        r = Record(word="string",
                    content=content,
                    source=self.dict.provider)
         self.dict.show(r)

--- a/zdict/tests/dictionaries/test_wiktionary.py
+++ b/zdict/tests/dictionaries/test_wiktionary.py
@@ -1,0 +1,68 @@
+from pytest import raises
+from unittest.mock import Mock, patch
+
+from zdict.dictionaries.wiktionary import WiktionaryDict
+from zdict.exceptions import NotFoundError, QueryError
+from zdict.models import Record
+from zdict.zdict import get_args
+
+
+class TestWiktionaryDict:
+    def setup_method(self, method):
+        self.dict = WiktionaryDict(get_args())
+
+    def teardown_method(self, method):
+        del self.dict
+
+    def test_provider(self):
+        assert self.dict.provider == 'wiktionary'
+
+    def test__get_url(self):
+        uri = 'https://en.wiktionary.org/api/rest_v1/page/definition/mock'
+        assert self.dict._get_url('mock') == uri
+
+    def test_query_notfound(self):
+        self.dict._get_raw = Mock(side_effect=QueryError('mock', 404))
+
+        with raises(NotFoundError):
+            self.dict.query('mock')
+
+        self.dict._get_raw.assert_called_with('mock')
+
+    @patch('zdict.dictionaries.wiktionary.Record')
+    def test_query_normal(self, Record):
+        self.dict._get_raw = Mock(return_value='{"mock": true}')
+        self.dict.query('mock')
+        Record.assert_called_with(
+            word='mock',
+            content='{"mock": true}',
+            source='wiktionary'
+        )
+
+    def test_show(self):
+        content = '''
+        {
+           "en":[
+              {
+                 "partOfSpeech":"string",
+                 "language":"string",
+                 "definitions":[
+                    {
+                       "definition":"string",
+                       "parsedExamples":[
+                          {
+                             "example":"string"
+                          }
+                       ],
+                       "examples":[
+                          "string"
+                       ]
+                    }]
+                }]
+        }
+        '''
+
+        r = Record(word='string',
+                   content=content,
+                   source=self.dict.provider)
+        self.dict.show(r)


### PR DESCRIPTION
**_This Pull Request refers to #196 issue._**

### Description:

**The API problem.** 
We can access wiktionary content through [WIKIMEDIA REST API](https://en.wiktionary.org/api/rest_v1/). Unfortunately this does not support ZH language (at least I think so). The [main API](https://en.wiktionary.org/w/api.php) supports it but it requires a ton of work to extract anything from it (Reason: The wiktionary is designed to be human readable). There are APIs that intend to provide wiktionary data but could not find anything that would not require to implement an API key.

**Support for more languages**
The WIKIMEDIA REST API does provide definitions in other languages, so it is probably a good idea to implement a way to support them using CLI arguments in the future.
