### PR TITLE
Add verbose mode to Wiktionary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,6 +195,14 @@ To use this source, you should first `apply <https://developer.oxforddictionarie
     app_id, app_key
 
 
+`Wiktionary <https://en.wiktionary.org/>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. image:: https://i.imgur.com/5OzIFU3.png
+
+.. image:: https://i.imgur.com/UO5nQjU.png
+
+
 Development & Contributing
 ---------------------------
 

--- a/zdict/dictionaries/wiktionary.py
+++ b/zdict/dictionaries/wiktionary.py
@@ -30,16 +30,16 @@ class WiktionaryDict(DictBase):
 
         for d in content:
             self.color.print(d['part_of_speech'], 'yellow', indent=2)
-            for i, definition in enumerate(d['definitions']):
-                self.color.print(f"{i+1}. {definition['definition']}",
+            for i, defin in enumerate(d['definitions']):
+                self.color.print("{}. {}".format(i+1, defin['definition']),
                                  'org', indent=4)
                 try:
-                    definition['examples']
+                    defin['examples']
                 except KeyError:
                     pass
                 else:
                     # self.color.print(f"Examples:", 'lindigo', indent=6)
-                    for example in definition['examples']:
+                    for example in defin['examples']:
                         self.color.print(example, 'indigo', indent=6)
 
     def query(self, word: str):

--- a/zdict/dictionaries/wiktionary.py
+++ b/zdict/dictionaries/wiktionary.py
@@ -28,19 +28,26 @@ class WiktionaryDict(DictBase):
         # Render the output.
         self.color.print(record.word, 'lyellow')
 
-        for d in content:
+        if self.args.verbose:
+            for d in content:
+                self.color.print(d['part_of_speech'], 'yellow', indent=2)
+                for i, defin in enumerate(d['definitions']):
+                    self.color.print("{}. {}".format(i+1, defin['definition']),
+                                     'org', indent=4)
+                    try:
+                        defin['examples']
+                    except KeyError:
+                        pass
+                    else:
+                        # self.color.print(f"Examples:", 'lindigo', indent=6)
+                        for example in defin['examples']:
+                            self.color.print(example, 'indigo', indent=6)
+        else:
+            d = content[0]
             self.color.print(d['part_of_speech'], 'yellow', indent=2)
-            for i, defin in enumerate(d['definitions']):
-                self.color.print("{}. {}".format(i+1, defin['definition']),
-                                 'org', indent=4)
-                try:
-                    defin['examples']
-                except KeyError:
-                    pass
-                else:
-                    # self.color.print(f"Examples:", 'lindigo', indent=6)
-                    for example in defin['examples']:
-                        self.color.print(example, 'indigo', indent=6)
+            self.color.print(d['definitions'][0]['definition'],
+                             'org',
+                             indent=4)
 
     def query(self, word: str):
         try:

--- a/zdict/dictionaries/wiktionary.py
+++ b/zdict/dictionaries/wiktionary.py
@@ -60,7 +60,7 @@ class WiktionaryDict(DictBase):
         try:
             # Get the first definition string from JSON.
             content = content['en']
-        except KeyError as exception:
+        except KeyError:
             # API can return JSON that does not contain 'en' language.
             raise NotFoundError(word)
 

--- a/zdict/tests/dictionaries/test_wiktionary.py
+++ b/zdict/tests/dictionaries/test_wiktionary.py
@@ -1,5 +1,6 @@
 from pytest import raises
 from unittest.mock import Mock, patch
+import json
 
 from zdict.dictionaries.wiktionary import WiktionaryDict
 from zdict.exceptions import NotFoundError, QueryError
@@ -31,17 +32,26 @@ class TestWiktionaryDict:
 
     @patch('zdict.dictionaries.wiktionary.Record')
     def test_query_normal(self, Record):
-        content = '{"en":[{"definitions":[{"definition":"string"}]}]}'
+        content = '''
+        {"en":[{"partOfSpeech":"part_of_speech",
+        "definitions":[{"definition":"definition","examples":["example"]}]}]}
+        '''
         self.dict._get_raw = Mock(return_value=content)
         self.dict.query('mock')
+        r_content = [{"part_of_speech": "part_of_speech",
+                      "definitions": [{"definition": "definition",
+                                       "examples": ["example"]}]}]
         Record.assert_called_with(
             word='mock',
-            content='{"definition": "string"}',
+            content=json.dumps(r_content),
             source='wiktionary'
         )
 
     def test_show(self):
-        content = '{"definition": "string"}'
+        content = '''
+        [{"part_of_speech":"part_of_speech",
+        "definitions":[{"definition": "definition","examples":["example"]}]}]
+        '''
 
         r = Record(word="string",
                    content=content,


### PR DESCRIPTION
### Description:

Previous version only showed the first definition provided by the API to the user.
This version does cover every part of speech , definitions and examples provided by the API :recycle:.
I'm really sad it turned out to be O(n^3) but can't think of a better solution right now.

There is also some code repetition in query and show function. I'm not sure if this is a problem. I tried to follow instructions provided in the dictionaries/template.py and that's why it turned out to be repetitive.

Sometimes there are repetitions in the API that are parsed to the Record, for example for a word 'box'. It is a good idea to fix this issue in the future.