### PR TITLE
[#357] Extends query_timeout for iTaigi to avoid timeout

### DIFF
--- a/zdict/tests/dictionaries/test_itaigi.py
+++ b/zdict/tests/dictionaries/test_itaigi.py
@@ -13,6 +13,9 @@ class TestiTaigiDict:
 
         cls.words = ['芭樂', '測試']
 
+        # Set query_timeout from 5 seconds to 60 seconds,
+        # so it won't timeout that often.
+        cls.dict.args.query_timeout = 60
         # Setup normal query data
         cls.dict.args.verbose = False
         cls.records = [cls.dict.query(word) for word in cls.words]


### PR DESCRIPTION
Try to set query_timeout from 5 secs to 60 secs for iTaigi.