### PR TITLE
[#428] Depracate `python setup.py test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# eython CircleCI 2.0 configuration file
+# Python CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ variables:
           name: run tests
           command: |
             . venv/bin/activate
-            python setup.py test
+            make test
 
       - store_test_results:
           path: test-reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,13 @@ script:
     - pip install -r requirements-test.txt
     - make test
 
+before_cache:
+    # Remove __pycahce__ dirs and *.pyc, *.pyo files before uploading cache.
+    # Which will changes between every single builds.
+    # This could make Travis CI don't upload cache every time.
+    - python3 -Bc "import pathlib; [p.unlink() for p in pathlib.Path('$HOME/venv').rglob('*.py[co]')]"
+    - python3 -Bc "import pathlib; [p.rmdir() for p in pathlib.Path('$HOME/venv').rglob('__pycache__')]"
+
 after_success:
     - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
     - pip freeze
 
 script:
+    - pip install -r requirements-test.txt
     - make test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
     - pip freeze
 
 script:
-    - python setup.py test
+    - make test
 
 after_success:
     - coveralls

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ clean: clean-pyc clean-vim-swap-files
 	rm -rf build dist htmlcov .coverage* .cache .eggs
 
 test:
-	python setup.py test
+	py.test
+
+test-with-pdb:
+	py.test --pdb
 
 # Make docker-zdict don't complain about no make rules for apple, bird, ...
 %:

--- a/README.rst
+++ b/README.rst
@@ -228,16 +228,19 @@ If you use `virtualenv`, you may want to create a new enviroment for `zdict`::
 
 Once you installed it with the command above,
 just execute `zdict` after modification.
-Don't need to install it again.
+No need to install it again.
+
+Install the packages for testing::
+
+    $ pip install pytest pytest-cov coverage
 
 We use ``py.test``::
 
-    $ pip install pytest pytest-cov coverage
-    $ python setup.py test
+    $ py.test
 
 or::
 
-    $ py.test
+    $ make test
 
 After runing testing, we will get a coverage report in html.
 We can browse around it::
@@ -254,11 +257,11 @@ Debugging
 
 ``py.test`` can prompt ``pdb`` shell when your test case failed::
 
-    $ python setup.py test -a "--pdb"
+    $ py.test --pdb
 
 or::
 
-    $ py.test --pdb
+    $ make test-with-pdb
 
 
 Bug Report

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import sys
 import os
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -40,25 +39,6 @@ def get_test_req():
 version = get_zdict_version()
 
 
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
 install_requirements = parse_requirements(
     os.path.join(ROOT_DIR, 'requirements.txt')
 )
@@ -72,7 +52,6 @@ setup(
     scripts=['scripts/zdict'],
     install_requires=install_requirements,
     tests_require=get_test_req(),
-    cmdclass={'test': PyTest},
 
     name='zdict',
     version=version,


### PR DESCRIPTION
- Use `py.test`
- Add `make test` and `make test-with-pdb` into Makefile
- Make Travis CI and CircleCI use `make test` while testing
- So we just have to modify Makefile if execute command for testing need to be changed in the future.
- Update README
- Remove `python setup.py test` related code in setup.py