### PR TITLE
[#495] Ignore "pronounce" field during iTaigi unittest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,8 +255,7 @@ jobs:
           command: |
             . venv/bin/activate
             pip install wheel
-            python setup.py sdist
-            python setup.py bdist_wheel
+            python setup.py sdist bdist_wheel
 
       - run:
           name: upload to pypi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,4 +262,5 @@ jobs:
           name: upload to pypi
           command: |
             . venv/bin/activate
+            twine check dist/*
             twine upload dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ flake8-ignore =
     # F841 - local variable name is assigned to but never used
 
 [bdist_wheel]
-python-tag = py36+
+python-tag = py36

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     keywords="cli, dictionary, framework",
     description="The last online dictionary framework you need. (?)",
     long_description=open("README.rst", encoding='utf-8').read(),
+    long_description_content_type="text/x-rst",
     download_url="https://github.com/zdict/zdict/archive/v{}.zip".format(
         version
     ),

--- a/zdict/tests/dictionaries/test_itaigi.py
+++ b/zdict/tests/dictionaries/test_itaigi.py
@@ -11,11 +11,18 @@ from zdict.dictionaries.itaigi import iTaigiDict
 def _filter_pronounce(d: dict) -> dict:
     new_d = {}
     for k, v in d.items():
+        # iTaigiDict sometimes return one item of result
+        # with same meaning but different pronounce
+        # which will make this unittest randomly fail.
         if k == "pronounce":
             continue
 
         if isinstance(v, dict):
             new_d[k] = _filter_pronounce(v)
+        elif isinstance(v, tuple):
+            new_d[k] = tuple(_filter_pronounce(_) for _ in v)
+        elif isinstance(v, list):
+            new_d[k] = list(_filter_pronounce(_) for _ in v)
         else:
             new_d[k] = v
     return new_d

--- a/zdict/tests/dictionaries/test_itaigi.py
+++ b/zdict/tests/dictionaries/test_itaigi.py
@@ -1,10 +1,24 @@
+import json
 import time
 from pytest import raises
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from zdict.exceptions import NotFoundError
 from zdict.zdict import get_args
 from zdict.dictionaries.itaigi import iTaigiDict
+
+
+def _filter_pronounce(d: dict) -> dict:
+    new_d = {}
+    for k, v in d.items():
+        if k == "pronounce":
+            continue
+
+        if isinstance(v, dict):
+            new_d[k] = _filter_pronounce(v)
+        else:
+            new_d[k] = v
+    return new_d
 
 
 class TestiTaigiDict:
@@ -84,43 +98,49 @@ class TestiTaigiDict:
         for record in self.verbose_records:
             self.dict.show(record)
 
-    @patch('zdict.dictionaries.itaigi.Record')
-    def test_query_normal(self, Record):
+    def test_query_normal(self):
         self.dict.args.verbose = False
 
+        query_record = None
         for i, word in enumerate(self.words):
             while True:
                 try:
-                    self.dict.query(word)
+                    query_record = self.dict.query(word)
                 except Exception:
                     # prevent itaigi API 500 error
                     time.sleep(5)
                     continue
                 else:
-                    Record.assert_called_with(
-                        word=word,
-                        content=self.records[i].content,
-                        source='itaigi',
+                    assert (
+                        _filter_pronounce(
+                            json.loads(query_record.content)
+                        ) ==
+                        _filter_pronounce(
+                            json.loads(self.records[i].content)
+                        )
                     )
                     break
 
-    @patch('zdict.dictionaries.itaigi.Record')
-    def test_query_verbose(self, Record):
+    def test_query_verbose(self):
         self.dict.args.verbose = True
 
+        verbose_query_record = None
         for i, word in enumerate(self.words):
             while True:
                 try:
-                    self.dict.query(word)
+                    verbose_query_record = self.dict.query(word)
                 except Exception:
                     # prevent itaigi API 500 error
                     time.sleep(5)
                     continue
                 else:
-                    Record.assert_called_with(
-                        word=word,
-                        content=self.verbose_records[i].content,
-                        source='itaigi',
+                    assert (
+                        _filter_pronounce(
+                            json.loads(verbose_query_record.content)
+                        ) ==
+                        _filter_pronounce(
+                            json.loads(self.verbose_records[i].content)
+                        )
                     )
                     break
 

--- a/zdict/tests/dictionaries/test_naer.py
+++ b/zdict/tests/dictionaries/test_naer.py
@@ -16,6 +16,10 @@ class TestNaerDict:
         cls.words = ['西爾河', 'spring mass']
         cls.not_found_word = 'dsafwwe'
 
+        # Set query_timeout from 5 seconds to 60 seconds,
+        # so it won't timeout that often.
+        cls.dict.args.query_timeout = 60
+
         # Setup normal query data
         cls.dict.args.verbose = False
         cls.records = [cls.dict.query(word) for word in cls.words]


### PR DESCRIPTION
iTaigi sometimes returns different result on pronounce. Ignore them in
the tests.